### PR TITLE
Order form submit doesn't work #14

### DIFF
--- a/application/src/components/order-form/orderForm.js
+++ b/application/src/components/order-form/orderForm.js
@@ -20,7 +20,7 @@ class OrderForm extends Component {
     }
 
     menuItemChosen(event) {
-        this.setState({ item: event.target.value });
+        this.setState({ order_item: event.target.value });
     }
 
     menuQuantityChosen(event) {


### PR DESCRIPTION
Updated setState value in the menuItemChosen function found in orderForm.js from "item" to "order_item" which matches with the state value found in the constructor that is used to represent the selected dropdown option model.