### PR TITLE
Order time does not format time correctly #30

### DIFF
--- a/application/src/components/view-orders/viewOrders.js
+++ b/application/src/components/view-orders/viewOrders.js
@@ -25,7 +25,7 @@ class ViewOrders extends Component {
             <Template>
                 <div className="container-fluid">
                     {this.state.orders.map(order => {
-                        const createdDate = new Date(order.createdAt);
+                        const createdDate = new Date(order.createdAt).toLocaleTimeString();
                         return (
                             <div className="row view-order-container" key={order._id}>
                                 <div className="col-md-4 view-order-left-col p-3">
@@ -33,7 +33,7 @@ class ViewOrders extends Component {
                                     <p>Ordered by: {order.ordered_by || ''}</p>
                                 </div>
                                 <div className="col-md-4 d-flex view-order-middle-col">
-                                    <p>Order placed at {`${createdDate.getHours()}:${createdDate.getMinutes()}:${createdDate.getSeconds()}`}</p>
+                                    <p>Order placed at {createdDate}</p>
                                     <p>Quantity: {order.quantity}</p>
                                  </div>
                                  <div className="col-md-4 view-order-right-col">


### PR DESCRIPTION
Edited the createdDate variable found in viewOrders.js to use the .toLocaleTimeString() javascript function that handles the missing formatting 0's found when the minute and second values are less than 10. This implementation utilizes built-in formatting tools mentioned in the challenge prompt.